### PR TITLE
Fix userstyle being applied globally (closes #17)

### DIFF
--- a/github.user.css
+++ b/github.user.css
@@ -67,6 +67,8 @@
 @var text wb-sb-radius "Webkit scrollbar border radius" 0px
 @preprocessor uso
 ==/UserStyle== */
+@-moz-document domain('raw.githubusercontent.com'),
+regexp('https?://((developer|gist)\.)?github\.com/.*') {
 :root {
   --base-1:  /*[[base-1]]*/ ;
   --base-2:  /*[[base-2]]*/ ;
@@ -112,6 +114,7 @@
   --ui-font: /*[[ui_font]]*/ ;
   --yellow: /*[[yellow]]*/ ;
   --yellow-trans: /*[[yellow-trans]]*/ ;
+}
 }
 @-moz-document domain('github.com'), domain('raw.githubusercontent.com') {
   .repository-content .bg-gray-dark.d-flex.flex-column.flex-auto.flex-justify-end,

--- a/metadata.css
+++ b/metadata.css
@@ -67,6 +67,8 @@
 @var text wb-sb-radius "Webkit scrollbar border radius" 0px
 @preprocessor uso
 ==/UserStyle== */
+@-moz-document domain('raw.githubusercontent.com'),
+regexp('https?://((developer|gist)\.)?github\.com/.*') {
 :root {
   --base-1:  /*[[base-1]]*/ ;
   --base-2:  /*[[base-2]]*/ ;
@@ -112,4 +114,5 @@
   --ui-font: /*[[ui_font]]*/ ;
   --yellow: /*[[yellow]]*/ ;
   --yellow-trans: /*[[yellow-trans]]*/ ;
+}
 }


### PR DESCRIPTION
Hi,

This PR adds the scope to CSS variables so that the userstyle only applies to
GitHub-specific domains.

P.S. Thank you for making this awesome project, and for mentioning my GitLab
userstyle in your recent r/unixporn post! :tada: