### PR TITLE
Fix notification focus style

### DIFF
--- a/github.user.css
+++ b/github.user.css
@@ -359,6 +359,7 @@
   .menu-item,
   .notifications-list-item:hover .notification-list-item-actions .btn,
   .notifications-list-item:focus .notification-list-item-actions .btn,
+  .notifications-list-item.navigation-focus .notification-list-item-actions .btn,
   .reponav-item,
   .reponav-item .octicon,
   .ajax-pagination-form > .Box > .bg-white,
@@ -3189,11 +3190,13 @@
     fill: var(--text-primary) !important;
   }
   .notifications-list-item:hover,
-  .notifications-list-item:focus {
+  .notifications-list-item:focus,
+  .notifications-list-item.navigation-focus {
     background-color: var(--base-5) !important;
   }
   .notifications-list-item:hover .notification-list-item-actions .btn:hover,
-  .notifications-list-item:focus .notification-list-item-actions .btn:hover {
+  .notifications-list-item:focus .notification-list-item-actions .btn:hover,
+  .notifications-list-item.navigation-focus .notification-list-item-actions .btn:hover {
     color: var(--text-light) !important;
     border-color: var(--base-1) !important;
     background-color: var(--base-1) !important;

--- a/src/notifications.styl
+++ b/src/notifications.styl
@@ -13,7 +13,7 @@
       c 0 1 4
     & &-actions svg
       vc fg("primary")
-    &:hover, &:focus
+    &:hover, &:focus, &.navigation-focus
       c 0 0 5
       .notification-list-item-actions .btn
         ease colors


### PR DESCRIPTION
At some point, GitHub added an additional focus style in the notification panel which seems to be the last notification item hovered (`.notifications-list-item.navigation-focus`).

It results in the notification panel looking like:

![image](https://user-images.githubusercontent.com/13353733/96191965-0bc7d780-0f3d-11eb-880a-c5eb48e526b0.png)

This PR resolves this issue by applying the same styles as the `:focus` & `:hover` selectors to this case:

![image](https://user-images.githubusercontent.com/13353733/96192290-a32d2a80-0f3d-11eb-860b-06cbfe651db5.png)
