### PR TITLE
Fix dark gray label text color

### DIFF
--- a/github.user.css
+++ b/github.user.css
@@ -2803,6 +2803,7 @@
     background-color: var(--base-2) !important;
   }
   .Label--gray-darker {
+    color: var(--text-gray-dark) !important;
     background-color: var(--base-1) !important;
   }
   .Label----orange {

--- a/src/label.styl
+++ b/src/label.styl
@@ -2,7 +2,7 @@
   &gray
     c fg("primary") 1 2
     &-darker
-      c 0 0 1
+      c fg("gray-dark") 0 1
   &--orange
     c 0 0 v("orange")
   &outline


### PR DESCRIPTION
I noticed that the text color on labels with the `gray-darker` modifier was a little too dark. An example is the `Required` annotation on the checks reporting on PRs: 

![image](https://user-images.githubusercontent.com/13353733/96193182-8bef3c80-0f3f-11eb-80d9-a4639f043050.png)


This PR fixes this issue by setting the foreground color to `grey-dark` (not sure what the most appropriate item here is). 

After:

![image](https://user-images.githubusercontent.com/13353733/96193229-a45f5700-0f3f-11eb-9d8e-80cfdf7c20eb.png)
