### PR TITLE
Fix open PR color

### DIFF
--- a/github.user.css
+++ b/github.user.css
@@ -2584,7 +2584,6 @@
   .octicon-repo-forked {
     margin-bottom: 0.1em !important;
   }
-  .octicon-git-pull-request,
   .octicon.merged {
     color: var(--purple) !important;
   }
@@ -2605,7 +2604,8 @@
   }
   .octicon-repo-push,
   .octicon-check,
-  .octicon.open {
+  .octicon.open,
+  .octicon-git-pull-request {
     color: var(--green) !important;
   }
   .octicon-rocket {

--- a/src/icons.styl
+++ b/src/icons.styl
@@ -15,7 +15,7 @@
   &-repo
     &, &-push, &-forked
       mb 0.1em
-  &-git-pull-request, &.merged
+  &.merged
     c v("purple")
   &-file-directory, &-saved
     c v("blue")
@@ -25,7 +25,7 @@
     c light("red")
   &-x, &-trashcan
     c v("red")
-  &-repo-push, &-check, &.open
+  &-repo-push, &-check, &.open, &-git-pull-request
     c v("green")
   &-rocket
     c fg("faded")


### PR DESCRIPTION
The open PR color in the notifications panel is currently purple, which everywhere else is used for a merged PR.

This can be seen here: 

![](https://user-images.githubusercontent.com/13353733/96191965-0bc7d780-0f3d-11eb-880a-c5eb48e526b0.png)

The two PRs under `jamiebrynes7/setup-spatialos-cli` are both currently open but display as merged.

This was originally fixed in https://github.com/Brettm12345/github-moonlight/commit/1480a6741c6615ddbfbe6b9eec93c655dee3d6da and regressed in https://github.com/Brettm12345/github-moonlight/commit/2e8b31221e046cf77b35e6e1292327cf0ac91b8d.

Related: #22